### PR TITLE
[skip ci] Github Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Misinformation campaign analysis
 
 ![License: MIT](https://img.shields.io/github/license/ssciwr/misinformation)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ssciwr/misinformation/CI)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/ssciwr/misinformation/ci.yml?branch=main)
 ![codecov](https://img.shields.io/codecov/c/github/ssciwr/misinformation)
 ![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ssciwr_misinformation&metric=alert_status)
 ![Language](https://img.shields.io/github/languages/top/ssciwr/misinformation)


### PR DESCRIPTION
There has been a backwards-incompatible change to shields.io badges for Github Actions. They now identify workflows by their filename instead of their name field.